### PR TITLE
Feature: Agile consumption statistics

### DIFF
--- a/custom_cards/agile-consumption-card.js
+++ b/custom_cards/agile-consumption-card.js
@@ -1,0 +1,200 @@
+class AgileConsumptionCard extends HTMLElement {
+    set hass(hass) {
+        if (!this.content) {
+            const card = document.createElement('ha-card');
+            card.header = this.title;
+            this.content = document.createElement('div');
+            this.content.style.padding = '0 16px 16px';
+
+            const style = document.createElement('style');
+            style.textContent = `
+            table {
+                width: 100%;
+                padding: 0px;
+                spacing: 0px;
+                font-size: 12px;
+            }
+            table.sub_table {
+                border-collapse: seperate;
+                border-spacing: 0px 2px;
+            }
+            table.main {
+                padding: 0px;
+            }
+            thead th {
+                text-align: left;
+                padding: 0px;
+            }
+            td {
+                vertical-align: top;
+                padding: 2px;
+                spacing: 0px;
+            }
+            tr.rate_row{
+                text-align:center;
+                width:80px;
+            }
+            td.time {
+                text-align:center;
+                vertical-align: middle;
+            }
+            td.time_red{
+                border-bottom: 1px solid Tomato;
+            }
+            td.time_orange{
+                border-bottom: 1px solid orange;
+            }
+            td.time_green{
+                border-bottom: 1px solid MediumSeaGreen;
+            }
+            td.time_blue{
+                border-bottom: 1px solid #391CD9;
+            }
+            td.rate {
+                color:white;
+                text-align:center;
+                vertical-align: middle;
+                width:80px;
+            }
+            td.red {
+                border: 2px solid Tomato;
+                background-color: Tomato;
+            }
+            td.orange {
+                border: 2px solid orange;
+                background-color: orange;
+            }
+            td.green {
+                border: 2px solid MediumSeaGreen;
+                background-color: MediumSeaGreen;
+            }
+            td.blue {
+                border: 2px solid #391CD9;
+                background-color: #391CD9;
+            }
+            `;
+            card.appendChild(style);
+            card.appendChild(this.content);
+            this.appendChild(card);
+        }
+
+        const entityId = this.config.entity;
+        const state = hass.states[entityId];
+        const attributes = this.reverseObject(state.attributes);
+        const stateStr = state ? state.state : 'unavailable';
+        var tables = "";
+        const rates_list_length = Object.keys(attributes).length;
+        const rows_per_col = Math.ceil(rates_list_length / this.cols);
+        tables = tables.concat("<td><table class='sub_table'><tbody>");
+        var table = ""
+        var x = 1;
+        const mediumlimit = this.mediumlimit;
+        const highlimit = this.highlimit;
+        const unitstr = this.unitstr;
+        const roundUnits = this.roundUnits
+
+        Object.keys(attributes).reverse().forEach(function (key) {
+            var colour = "green";
+            if(attributes[key] > highlimit) colour = "red";
+            else if(attributes[key] > mediumlimit) colour = "orange";
+            else if(attributes[key] <= 0 ) colour = "blue";
+            table = table.concat("<tr class='rate_row'><td class='time time_"+colour+"'>" + key + "</td><td class='rate "+colour+"'>" + attributes[key].toFixed(roundUnits) + unitstr + "</td></tr>");
+            if (x % rows_per_col == 0) {
+                tables = tables.concat(table);
+                table = "";
+                if (rates_list_length != x) {
+                    tables = tables.concat("</tbody></table></td>");
+                    tables = tables.concat("<td><table class='sub_table'><tbody>");
+                }
+            };
+            x++;
+
+        });
+        tables = tables.concat(table);
+        tables = tables.concat("</tbody></table></td>");
+
+        this.content.innerHTML = `
+        <table class="main">
+            <tr>
+                ${tables}
+            </tr>
+        </table>
+        `;
+    }
+
+
+    reverseObject(object) {
+        var newObject = {};
+        var keys = [];
+
+        for (var key in object) {
+            keys.push(key);
+        }
+
+        for (var i = keys.length - 1; i >= 0; i--) {
+            var value = object[keys[i]];
+            newObject[keys[i]] = value;
+        }
+
+        return newObject;
+    }
+
+    setConfig(config) {
+        if (!config.entity) {
+            throw new Error('You need to define an entity');
+        }
+
+
+        this.config = config;
+        if (!config.cols) {
+            this.cols = 1;
+        }
+        else {
+            this.cols = config.cols;
+        }
+
+        if (!config.title) {
+            this.title = 'Agile Consumption';
+        }
+        else {
+            this.title = config.title;
+        }
+
+        if (!config.mediumlimit) {
+            this.mediumlimit = 10;
+        }
+        else {
+            this.mediumlimit = config.mediumlimit;
+        }
+
+        if (!config.highlimit) {
+            this.highlimit = 15;
+        }
+        else {
+            this.highlimit = config.highlimit;
+        }
+
+        if (!config.roundUnits) {
+            this.roundUnits = 2;
+        }
+        else {
+            this.roundUnits = config.roundUnits;
+        }
+
+        if(!config.showunits) {
+            this.unitstr = "kWh";
+        }
+        else {
+            if(config.showunits == "true") this.unitstr = "kWh";
+            else this.unitstr = "";
+        }
+    }
+
+    // The height of your card. Home Assistant uses this to automatically
+    // distribute all cards over the available columns.
+    getCardSize() {
+        return 3;
+    }
+}
+
+customElements.define('agile-consumption-card', AgileConsumptionCard);

--- a/custom_components/octopusagile/__init__.py
+++ b/custom_components/octopusagile/__init__.py
@@ -357,6 +357,10 @@ def setup(hass, config):
                            round(monthlycost/100, 2),
                            attributes={'unit_of_measurement': '£',
                                        'icon': 'mdi:cash'})
+        hourly, daily, hour_daily = myrates.aggregate_consumption()
+        hass.states.set(f"octopusagile.hourly_consumption", "", hourly)
+        hass.states.set(f"octopusagile.daily_consumption", "", daily)
+        hass.states.set(f"octopusagile.hour_daily_consumption", "", hour_daily)
 
     def half_hour_timer(nowtime):
         roundedtime = myrates.round_time(nowtime)


### PR DESCRIPTION
This implements a few fairly simple aggregations for consumption metrics. The results are saved similarly to `rates` in `home_assistant.states`. You can then display them with a custom card.

Few notes:
- Statistics are rolling based **on last 30 days of usage**. This can be turned into a configurable setting.
- New statistics:
   - Hourly aggregation
   - Weekday aggregation
   - Combination of hourly & weekday aggregation

Few screenshots:
<img width="504" alt="image" src="https://user-images.githubusercontent.com/6807878/119267588-3ec6fd80-bbe7-11eb-83d1-a4d58037ab4a.png">

<img width="494" alt="image" src="https://user-images.githubusercontent.com/6807878/119267602-48e8fc00-bbe7-11eb-90f8-967c99432357.png">

<img width="498" alt="image" src="https://user-images.githubusercontent.com/6807878/119267614-51d9cd80-bbe7-11eb-9574-c4499de896a5.png">


