### PR TITLE
Feature/run after

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ octopusagile:
   run_devices:
   - energy_time: 2.5
     entity_id: dishwasher
+    run_after: '06:00:00' # This is optional
     run_before: '08:00:00'
     run_time: 3.5
   - energy_time: 2.5

--- a/custom_components/octopusagile/OctopusAgile/Agile.py
+++ b/custom_components/octopusagile/OctopusAgile/Agile.py
@@ -159,6 +159,11 @@ class Agile:
         keys = list(d.keys())
         avgs = {}
         avg_times = {}
+
+        # If we have less rates than required hours, then we've missed our window
+        if (len(keys) < slots):
+            return None
+
         for index, obj in enumerate(keys):
             this_avg = []
             this_avg_times = []

--- a/custom_components/octopusagile/__init__.py
+++ b/custom_components/octopusagile/__init__.py
@@ -291,7 +291,7 @@ def setup(hass, config):
                     start_in = (start_time_obj - rounded_time).total_seconds()/3600
                     end_in = start_in + run_time
                     attribs = {"start_time": start_time, "start_in": start_in, "end_in": end_in, "rate": rate, "device_class": "timestamp"}
-                    hass.states.set(f"octopusagile.{entity_id}", start_time, attribs)
+                    hass.states.set(f"sensor.octopusagile_{entity_id}", dt_util.as_utc(start_time_obj), attribs)
                     device_times[entity_id] = {"start_time": start_time_obj, "attribs": attribs}
             except:
                 _LOGGER.error(f"Failed to update run_devices for {entity_id}")


### PR DESCRIPTION
Did this on a fork, and thought it might be useful in the main repo

I've added support for an optional `run_after` in `run_devices`. This means that a run device can find the best period of time within a given window (e.g. find the best time when people are usually out of the house).

BREAKING CHANGE: As part of this, I also renamed the run device sensor to have a `sensor` prefix instead of `octopusagile`. The main reason for this is so the state can be used as part of a [time trigger](https://www.home-assistant.io/docs/automation/trigger/#sensors-of-datetime-device-class). This is useful for automations that may require additional logic or play into a bigger picture.