### PR TITLE
Allow for selection of Agile Tariff

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,14 @@ This should match the [DNO region code](https://www.energy-stats.uk/dno-region-c
 ### mpan, serial, and auth
 Your MPAN and serial number are listed on your [API dashboard page](https://octopus.energy/dashboard/developer/). "*auth*" is your API key from the same page.
 
+### agilerate
+As of July 2022 there are now 3 Agile Tariffs :
+  * AGILE-18-02-21 - The unit rate is capped at 35p/kWh (including VAT)
+  * AGILE-22-07-22 - The unit rate is capped at 55p/kWh (including VAT)
+  * AGILE-22-08-31 - The unit rate is capped at 78p/kWh (including VAT)
+
+default if not set is AGILE-18-02-21
+
 ### moneymakers
 The concept of moneymakers is devices that should always turn on if the price drops to 0 or below.
 This can either be a switch or climate device. Note that I have only tested this with my tado thermostat.

--- a/custom_components/octopusagile/OctopusAgile/Agile.py
+++ b/custom_components/octopusagile/OctopusAgile/Agile.py
@@ -16,6 +16,7 @@ class Agile:
     MPAN = None
     SERIAL = None
     gas = None
+    agilerate = "AGILE-18-02-21"
 
     def round_time(self, t):
     # Rounds to nearest half hour
@@ -24,10 +25,11 @@ class Agile:
             minute = 30
         return (t.replace(second=0, microsecond=0, minute=minute, hour=t.hour))
 
-    def __init__(self, area_code=None, auth=None, mpan=None, serial=None, gas=None, gorate=None, godayrate=None, gotimes=[]):
+    def __init__(self, area_code=None, auth=None, mpan=None, serial=None, gas=None, agilerate="AGILE-18-02-21", gorate=None, godayrate=None, gotimes=[]):
         self.base_url = 'https://api.octopus.energy/v1'
+        self.agilerate = agilerate
         self.meter_points_url = f'{self.base_url}/electricity-meter-points/'
-        self.cost_url = f'{self.base_url}/products/AGILE-18-02-21/electricity-tariffs'
+        self.cost_url = f'{self.base_url}/products/{self.agilerate}/electricity-tariffs'
 
         self.auth = auth
         self.MPAN = mpan
@@ -58,7 +60,7 @@ class Agile:
             'v1/electricity-meter-points/' + str(self.MPAN) + '/meters/' + \
             str(self.SERIAL) + '/consumption/'
         costurl = 'https://api.octopus.energy/v1/products/' + \
-            'AGILE-18-02-21/electricity-tariffs/E-1R-AGILE-18-02-21-' + \
+            f'{self.agilerate}/electricity-tariffs/E-1R-{self.agilerate}-' + \
             str(area_code).upper() + '/standard-unit-rates/'
 
         # self.area_code = area_code
@@ -193,7 +195,7 @@ class Agile:
             date_to = ""
         headers = {'content-type': 'application/json'}
         r = requests.get(f'{self.cost_url}/'
-                         f'E-1R-AGILE-18-02-21-{self.area_code}/'
+                         f'E-1R-{self.agilerate}-{self.area_code}/'
                          f'standard-unit-rates/{ date_from }{ date_to }', headers=headers)
         # print(r)
         results = r.json()
@@ -219,11 +221,10 @@ class Agile:
         #     date_to = ""
         # headers = {'content-type': 'application/json'}
         # r = requests.get(f'{self.cost_url}/'
-        #                  f'E-1R-AGILE-18-02-21-{self.area_code}/'
+        #                  f'E-1R-{self.agilerate}-{self.area_code}/'
         #                  f'standard-unit-rates/{ date_from }{ date_to }', headers=headers)
         # results = r.json()["results"]
         results = self.get_raw_rates_json(date_from, date_to)["results"]
-        # _LOGGER.debug(r.url)
         return results
 
     def get_new_rates(self):

--- a/custom_components/octopusagile/__init__.py
+++ b/custom_components/octopusagile/__init__.py
@@ -61,7 +61,8 @@ def setup(hass, config):
         gorate = config["octopusagile"].get("gorate", None)
         godayrate = config["octopusagile"].get("godayrate", None)
         gotimes = config["octopusagile"].get("gotimes", [])
-        myrates = Agile(area_code=region_code, auth=auth, mpan=mpan, serial=serial, gorate=gorate, godayrate=godayrate, gotimes=gotimes)
+        agilerate = config["octopusagile"].get("agilerate","AGILE-18-02-21")
+        myrates = Agile(area_code=region_code, auth=auth, mpan=mpan, serial=serial, agilerate=agilerate, gorate=gorate, godayrate=godayrate, gotimes=gotimes)
         hass.states.set(f"octopusagile.region_code", region_code)
         startdate = config["octopusagile"]["startdate"]
         hass.states.set(f"octopusagile.startdate", startdate)

--- a/custom_components/octopusagile/manifest.json
+++ b/custom_components/octopusagile/manifest.json
@@ -11,6 +11,6 @@
   "codeowners": [
     "@markgdev"
   ],
-  "version": "2021.3.0b0",
+  "version": "2022.10.0b0",
   "iot_class": "cloud_polling"
 }


### PR DESCRIPTION
As of July 2022 there are now 3 Agile Tariffs :
  * AGILE-18-02-21 - The unit rate is capped at 35p/kWh (including VAT)
  * AGILE-22-07-22 - The unit rate is capped at 55p/kWh (including VAT)
  * AGILE-22-08-31 - The unit rate is capped at 78p/kWh (including VAT)

this allows selection of which rates to fetch default if not set is AGILE-18-02-21

Addresses #96 